### PR TITLE
Feature/multiple dll handling

### DIFF
--- a/IL2C.Core/ILConveters/ConvConverters.cs
+++ b/IL2C.Core/ILConveters/ConvConverters.cs
@@ -282,7 +282,7 @@ namespace IL2C.ILConverters
         public override ExpressionEmitter Prepare(DecodeContext decodeContext)
         {
             var siFrom = decodeContext.PopStack();
-            if (!(siFrom.TargetType.IsSingleType || siFrom.TargetType.IsDoubleType))
+            if (!siFrom.TargetType.IsNumericPrimitive)
             {
                 throw new InvalidProgramSequenceException(
                     "Cannot convert to floating point type: Location={0}, FromType={1}",
@@ -305,7 +305,7 @@ namespace IL2C.ILConverters
         public override ExpressionEmitter Prepare(DecodeContext decodeContext)
         {
             var siFrom = decodeContext.PopStack();
-            if (!(siFrom.TargetType.IsSingleType || siFrom.TargetType.IsDoubleType))
+            if (!siFrom.TargetType.IsNumericPrimitive)
             {
                 throw new InvalidProgramSequenceException(
                     "Cannot convert to floating point type: Location={0}, FromType={1}",

--- a/IL2C.Core/ILConveters/LdelemConverters.cs
+++ b/IL2C.Core/ILConveters/LdelemConverters.cs
@@ -46,8 +46,7 @@ namespace IL2C.ILConverters
             }
 
             var siArray = decodeContext.PopStack();
-            if (!(siArray.TargetType.IsArray &&
-                validateElementType(siArray.TargetType.ElementType)))
+            if (!(siArray.TargetType.IsArray && validateElementType(siArray.TargetType.ElementType)))
             {
                 throw new InvalidProgramSequenceException(
                     "Invalid array element type: Location={0}, StackType={1}",

--- a/IL2C.Core/ILConveters/StelemConverters.cs
+++ b/IL2C.Core/ILConveters/StelemConverters.cs
@@ -26,16 +26,18 @@ using IL2C.Metadata;
 
 namespace IL2C.ILConverters
 {
-    internal sealed class Stelem_i4ConvertersConverter : InlineNoneConverter
+    internal static class StelemConverterUtilities
     {
-        public override OpCode OpCode => OpCodes.Stelem_I4;
-
-        public override ExpressionEmitter Prepare(DecodeContext decodeContext)
+        public static ExpressionEmitter Prepare(
+            Func<ITypeInformation, bool> validateElementValueType,
+            Func<ITypeInformation, ITypeInformation, bool> validateElementType,
+            Func<ITypeInformation, string> arrayCTypeSymbol,
+            DecodeContext decodeContext)
         {
             // ECMA-335 III.4.26 stelem.<type> - store element to array
 
             var siValue = decodeContext.PopStack();
-            if (!siValue.TargetType.IsNumericPrimitive)
+            if (!validateElementValueType(siValue.TargetType))
             {
                 throw new InvalidProgramSequenceException(
                     "Invalid store type: Location={0}, StackType={1}",
@@ -53,8 +55,7 @@ namespace IL2C.ILConverters
             }
 
             var siArray = decodeContext.PopStack();
-            if (!(siArray.TargetType.IsArray &&
-                siArray.TargetType.ElementType.IsInt32StackFriendlyType))
+            if (!(siArray.TargetType.IsArray && validateElementType(siArray.TargetType.ElementType, siValue.TargetType)))
             {
                 throw new InvalidProgramSequenceException(
                     "Invalid array element type: Location={0}, StackType={1}",
@@ -65,9 +66,99 @@ namespace IL2C.ILConverters
             return (extractContext, _) => new[] {
                 string.Format("il2c_array_item({0}, {1}, {2}) = {3}",
                     extractContext.GetSymbolName(siArray),
-                    siArray.TargetType.ElementType.MangledUniqueName,
+                    arrayCTypeSymbol(siArray.TargetType.ElementType),
                     extractContext.GetSymbolName(siIndex),
                     extractContext.GetRightExpression(siArray.TargetType.ElementType, siValue)) };
+        }
+    }
+
+    internal sealed class Stelem_i1ConvertersConverter : InlineNoneConverter
+    {
+        public override OpCode OpCode => OpCodes.Stelem_I1;
+
+        public override ExpressionEmitter Prepare(DecodeContext decodeContext)
+        {
+            return StelemConverterUtilities.Prepare(
+                elementValueType => elementValueType.IsNumericPrimitive,
+                (elementType, elementValueType) => elementType.IsInt32StackFriendlyType || elementType.IsIntPtrStackFriendlyType,
+                arrayType => arrayType.MangledUniqueName,
+                decodeContext
+                );
+        }
+    }
+
+    internal sealed class Stelem_i2ConvertersConverter : InlineNoneConverter
+    {
+        public override OpCode OpCode => OpCodes.Stelem_I2;
+
+        public override ExpressionEmitter Prepare(DecodeContext decodeContext)
+        {
+            return StelemConverterUtilities.Prepare(
+                elementValueType => elementValueType.IsNumericPrimitive,
+                (elementType, elementValueType) => elementType.IsInt32StackFriendlyType || elementType.IsIntPtrStackFriendlyType,
+                arrayType => arrayType.MangledUniqueName,
+                decodeContext
+                );
+        }
+    }
+
+    internal sealed class Stelem_i4ConvertersConverter : InlineNoneConverter
+    {
+        public override OpCode OpCode => OpCodes.Stelem_I4;
+
+        public override ExpressionEmitter Prepare(DecodeContext decodeContext)
+        {
+            return StelemConverterUtilities.Prepare(
+                elementValueType => elementValueType.IsNumericPrimitive,
+                (elementType, elementValueType) => elementType.IsInt32StackFriendlyType || elementType.IsIntPtrStackFriendlyType,
+                arrayType => arrayType.MangledUniqueName,
+                decodeContext
+                );
+        }
+    }
+
+    internal sealed class Stelem_i8ConvertersConverter : InlineNoneConverter
+    {
+        public override OpCode OpCode => OpCodes.Stelem_I8;
+
+        public override ExpressionEmitter Prepare(DecodeContext decodeContext)
+        {
+            return StelemConverterUtilities.Prepare(
+                elementValueType => elementValueType.IsNumericPrimitive,
+                (elementType, elementValueType) => elementType.IsInt64StackFriendlyType,
+                arrayType => arrayType.MangledUniqueName,
+                decodeContext
+                );
+        }
+    }
+
+    internal sealed class Stelem_r4ConvertersConverter : InlineNoneConverter
+    {
+        public override OpCode OpCode => OpCodes.Stelem_R4;
+
+        public override ExpressionEmitter Prepare(DecodeContext decodeContext)
+        {
+            return StelemConverterUtilities.Prepare(
+                elementValueType => elementValueType.IsFloatStackFriendlyType,
+                (elementType, elementValueType) => elementType.IsFloatStackFriendlyType,
+                arrayType => arrayType.MangledUniqueName,
+                decodeContext
+                );
+        }
+    }
+
+    internal sealed class Stelem_r8ConvertersConverter : InlineNoneConverter
+    {
+        public override OpCode OpCode => OpCodes.Stelem_R8;
+
+        public override ExpressionEmitter Prepare(DecodeContext decodeContext)
+        {
+            return StelemConverterUtilities.Prepare(
+                elementValueType => elementValueType.IsFloatStackFriendlyType,
+                (elementType, elementValueType) => elementType.IsFloatStackFriendlyType,
+                arrayType => arrayType.MangledUniqueName,
+                decodeContext
+                );
         }
     }
 
@@ -77,43 +168,12 @@ namespace IL2C.ILConverters
 
         public override ExpressionEmitter Prepare(DecodeContext decodeContext)
         {
-            // ECMA-335 III.4.26 stelem.<type> - store element to array
-
-            var siValue = decodeContext.PopStack();
-            if (!siValue.TargetType.IsReferenceType)
-            {
-                throw new InvalidProgramSequenceException(
-                    "Invalid store type: Location={0}, StackType={1}",
-                    decodeContext.CurrentCode.RawLocation,
-                    siValue.TargetType.FriendlyName);
-            }
-
-            var siIndex = decodeContext.PopStack();
-            if (!(siIndex.TargetType.IsInt32StackFriendlyType || siIndex.TargetType.IsIntPtrStackFriendlyType))
-            {
-                throw new InvalidProgramSequenceException(
-                    "Invalid index type: Location={0}, StackType={1}",
-                    decodeContext.CurrentCode.RawLocation,
-                    siIndex.TargetType.FriendlyName);
-            }
-
-            var siArray = decodeContext.PopStack();
-            if (!(siArray.TargetType.IsArray &&
-                siArray.TargetType.ElementType.IsAssignableFrom(siValue.TargetType)))
-            {
-                throw new InvalidProgramSequenceException(
-                    "Invalid array element type: Location={0}, ArrayType={1}, StackType={2}",
-                    decodeContext.CurrentCode.RawLocation,
-                    siArray.TargetType.FriendlyName,
-                    siValue.TargetType.FriendlyName);
-            }
-
-            return (extractContext, _) => new[] {
-                string.Format("il2c_array_item({0}, {1}, {2}) = {3}",
-                    extractContext.GetSymbolName(siArray),
-                    siArray.TargetType.ElementType.CLanguageTypeName,
-                    extractContext.GetSymbolName(siIndex),
-                    extractContext.GetRightExpression(siArray.TargetType.ElementType, siValue)) };
+            return StelemConverterUtilities.Prepare(
+                elementValueType => elementValueType.IsReferenceType,
+                (elementType, elementValueType) => elementType.IsAssignableFrom(elementValueType),
+                arrayType => arrayType.CLanguageTypeName,
+                decodeContext
+                );
         }
     }
 
@@ -123,46 +183,12 @@ namespace IL2C.ILConverters
 
         public override ExpressionEmitter Prepare(ITypeInformation operand, DecodeContext decodeContext)
         {
-            // ECMA-335 III.4.26 stelem.<type> - store element to array
-
-            var siValue = decodeContext.PopStack();
-            if (!operand.IsAssignableFrom(siValue.TargetType))
-            {
-                throw new InvalidProgramSequenceException(
-                    "Invalid array element type: Location={0}, ElementType={1}, StackType={2}",
-                    decodeContext.CurrentCode.RawLocation,
-                    operand.FriendlyName,
-                    siValue.TargetType.FriendlyName);
-            }
-
-            var siIndex = decodeContext.PopStack();
-            if (!(siIndex.TargetType.IsInt32StackFriendlyType || siIndex.TargetType.IsIntPtrStackFriendlyType))
-            {
-                throw new InvalidProgramSequenceException(
-                    "Invalid index type: Location={0}, ElementType={1}, StackType={2}",
-                    decodeContext.CurrentCode.RawLocation,
-                    operand.FriendlyName,
-                    siIndex.TargetType.FriendlyName);
-            }
-
-            var siArray = decodeContext.PopStack();
-            if (!(siArray.TargetType.IsArray &&
-                siArray.TargetType.ElementType.IsAssignableFrom(siValue.TargetType)))
-            {
-                throw new InvalidProgramSequenceException(
-                    "Invalid array element type: Location={0}, ArrayType={1}, ElementType={2}, StackType={3}",
-                    decodeContext.CurrentCode.RawLocation,
-                    siArray.TargetType.FriendlyName,
-                    operand.FriendlyName,
-                    siValue.TargetType.FriendlyName);
-            }
-
-            return (extractContext, _) => new[] {
-                string.Format("il2c_array_item({0}, {1}, {2}) = {3}",
-                    extractContext.GetSymbolName(siArray),
-                    operand.CLanguageTypeName,
-                    extractContext.GetSymbolName(siIndex),
-                    extractContext.GetRightExpression(siArray.TargetType.ElementType, siValue)) };
+            return StelemConverterUtilities.Prepare(
+                elementValueType => operand.IsAssignableFrom(elementValueType),
+                (elementType, elementValueType) => elementType.IsAssignableFrom(elementValueType),
+                arrayType => operand.CLanguageTypeName,
+                decodeContext
+                );
         }
     }
 }

--- a/IL2C.Core/Metadata/BasePathAssemblyResolver.cs
+++ b/IL2C.Core/Metadata/BasePathAssemblyResolver.cs
@@ -21,28 +21,18 @@ using Mono.Cecil;
 
 namespace IL2C.Metadata
 {
-    internal sealed class BasePathAssemblyResolver : IAssemblyResolver
+    internal sealed class BasePathAssemblyResolver : DefaultAssemblyResolver
     {
-        private readonly DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
-
         public BasePathAssemblyResolver(string basePath)
         {
-            resolver.AddSearchDirectory(basePath);
+            this.AddSearchDirectory(basePath);
         }
 
-        public void Dispose()
+        public override AssemblyDefinition Resolve(AssemblyNameReference name)
         {
-            resolver.Dispose();
-        }
-
-        public AssemblyDefinition Resolve(AssemblyNameReference name)
-        {
-            return resolver.Resolve(name);
-        }
-
-        public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
-        {
-            return resolver.Resolve(name, parameters);
+            var definition = base.Resolve(name);
+            this.RegisterAssembly(definition);
+            return definition;
         }
     }
 }

--- a/IL2C.Core/Metadata/MetadataContext.cs
+++ b/IL2C.Core/Metadata/MetadataContext.cs
@@ -310,9 +310,9 @@ namespace IL2C.Metadata
                         var typeDefinition = typeReference.Resolve();
                         // TODO: try to resolve typeDefinition from mscorelib
                         if (typeDefinition == null)
-                            throw new InvalidProgramSequenceException(
-                                $"cannot resolve type {typeReference.FullName}"
-                                );
+                        {
+                            throw new InvalidProgramSequenceException($"cannot resolve type {typeReference.FullName}");
+                        }
                         if (typeDefinition.IsClass && !typeDefinition.IsAbstract &&
                             MemberReferenceComparer.Instance.Equals(
                                 typeDefinition.BaseType, ((TypeInformation)MulticastDelegateType).Member))

--- a/IL2C.Core/SimpleDriver.cs
+++ b/IL2C.Core/SimpleDriver.cs
@@ -68,7 +68,7 @@ namespace IL2C
             DebugInformationOptions debugInformationOptions,
             IEnumerable<string> assemblyPaths)
         {
-            foreach (var aseemblyPath in assemblyPaths)
+            foreach (var assemblyPath in assemblyPaths)
             {
                 Translate(
                     logw,
@@ -77,7 +77,7 @@ namespace IL2C
                     enableBundler,
                     targetPlatform,
                     debugInformationOptions,
-                    aseemblyPath);
+                    assemblyPath);
             }
         }
 
@@ -116,7 +116,7 @@ namespace IL2C
                 enableCpp,
                 "    ");
 
-            foreach (var aseemblyPath in assemblyPaths)
+            foreach (var assemblyPath in assemblyPaths)
             {
                 Translate(
                     logw,
@@ -125,7 +125,7 @@ namespace IL2C
                     enableBundler,
                     targetPlatform,
                     debugInformationOptions,
-                    aseemblyPath);
+                    assemblyPath);
             }
         }
 

--- a/IL2C.Core/TranslateContext.cs
+++ b/IL2C.Core/TranslateContext.cs
@@ -167,7 +167,7 @@ namespace IL2C
 
         IEnumerable<ITypeInformation> IExtractContext.EnumerateDeclaredTypes()
         {
-            return registeredTypesByDeclaringType.Values.SelectMany(typeInfo => typeInfo.ToList()).Distinct();
+            return registeredTypesByDeclaringType.Values.SelectMany(typeInfo => typeInfo).Distinct();
         }
 
         IEnumerable<string> IExtractContext.EnumerateRequiredImportIncludeFileNames() =>

--- a/IL2C.Core/TranslateContext.cs
+++ b/IL2C.Core/TranslateContext.cs
@@ -165,6 +165,11 @@ namespace IL2C
             return list ?? Enumerable.Empty<ITypeInformation>();
         }
 
+        IEnumerable<ITypeInformation> IExtractContext.EnumerateDeclaredTypes()
+        {
+            return registeredTypesByDeclaringType.Values.SelectMany(typeInfo => typeInfo.ToList()).Distinct();
+        }
+
         IEnumerable<string> IExtractContext.EnumerateRequiredImportIncludeFileNames() =>
             importIncludes;
 

--- a/IL2C.Core/Translators/IExtractContext.cs
+++ b/IL2C.Core/Translators/IExtractContext.cs
@@ -56,6 +56,7 @@ namespace IL2C.Translators
 
         IReadOnlyDictionary<MemberScopes, IEnumerable<ITypeInformation>> EnumerateRegisteredTypes();
         IEnumerable<ITypeInformation> EnumerateRegisteredTypesByDeclaringType(ITypeInformation declaringType);
+        IEnumerable<ITypeInformation> EnumerateDeclaredTypes();
         IEnumerable<string> EnumerateRequiredImportIncludeFileNames();
         IEnumerable<(string symbolName, string value)> ExtractConstStrings();
         IEnumerable<DeclaredValuesInformation> ExtractDeclaredValues();

--- a/IL2C.Core/Writers/HeaderWriter.cs
+++ b/IL2C.Core/Writers/HeaderWriter.cs
@@ -179,9 +179,7 @@ namespace IL2C.Writers
                 twHeader.SplitLine();
 
                 // Write assembly references.
-                var assemblies = extractContext.EnumerateRegisteredTypes().
-                    SelectMany(entry => entry.Value).
-                    Distinct().
+                var assemblies = extractContext.EnumerateDeclaredTypes().
                     OrderByDependant(translateContext.Assembly).
                     Select(type => type.DeclaringModule.DeclaringAssembly).
                     Where(assembly => !assembly.Equals(translateContext.Assembly)).

--- a/IL2C.Tasks/build/IL2C.Build.targets
+++ b/IL2C.Tasks/build/IL2C.Build.targets
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <IL2CTargetAssemblyFileName Condition="'$(IL2CTargetAssemblyFileName)' == ''">$([System.String]::Concat('$(AssemblyName)','$(TargetExt)'))</IL2CTargetAssemblyFileName>
     <IL2CTargetAssemblyPath Condition="'$(IL2CTargetAssemblyPath)' == ''">$([System.IO.Path]::Combine('$(ProjectDir)','$(OutputPath)','$(IL2CTargetAssemblyFileName)'))</IL2CTargetAssemblyPath>
-    <IL2CAssemblyPaths Condition="'$(IL2CAssemblyPaths)' == ''">$(IL2CTargetAssemblyPath)</IL2CAssemblyPaths>
     <IL2CAssemblyPaths Condition="'$(IL2CAssemblyPaths)' != ''">$([System.String]::Concat('$(IL2CAssemblyPaths)',';','$(IL2CTargetAssemblyPath)').split(';'))</IL2CAssemblyPaths>
+    <IL2CAssemblyPaths Condition="'$(IL2CAssemblyPaths)' == ''">$(IL2CTargetAssemblyPath)</IL2CAssemblyPaths>
     <IL2COutputPath Condition="'$(IL2COutputPath)' == ''">$([System.IO.Path]::Combine('$(ProjectDir)','$(OutputPath)','IL2C'))</IL2COutputPath>
     <IL2CDebugInformation Condition="'$(IL2CDebugInformation)' == ''">Full</IL2CDebugInformation>
     <IL2CReadSymbols Condition="'$(IL2CReadSymbols)' == ''">true</IL2CReadSymbols>

--- a/IL2C.Tasks/build/IL2C.Build.targets
+++ b/IL2C.Tasks/build/IL2C.Build.targets
@@ -1,21 +1,22 @@
 ﻿<Project>
-    <PropertyGroup>
-        <IL2CTargetAssemblyFileName Condition="'$(IL2CTargetAssemblyFileName)' == ''">$([System.String]::Concat('$(AssemblyName)','$(TargetExt)'))</IL2CTargetAssemblyFileName>
-        <IL2CTargetAssemblyPath Condition="'$(IL2CTargetAssemblyPath)' == ''">$([System.IO.Path]::Combine('$(ProjectDir)','$(OutputPath)','$(IL2CTargetAssemblyFileName)'))</IL2CTargetAssemblyPath>
-        <IL2CAssemblyPaths>$(IL2CTargetAssemblyPath)</IL2CAssemblyPaths>
-        <IL2COutputPath Condition="'$(IL2COutputPath)' == ''">$([System.IO.Path]::Combine('$(ProjectDir)','$(OutputPath)','IL2C'))</IL2COutputPath>
-        <IL2CDebugInformation Condition="'$(IL2CDebugInformation)' == ''">Full</IL2CDebugInformation>
-        <IL2CReadSymbols Condition="'$(IL2CReadSymbols)' == ''">true</IL2CReadSymbols>
-        <IL2CEnableCpp Condition="'$(IL2CEnableCpp)' == ''">false</IL2CEnableCpp>
-        <IL2CEnableBundler Condition="'$(IL2CEnableBundler)' == ''">false</IL2CEnableBundler>
-        <IL2CTargetPlatform Condition="'$(IL2CTargetPlatform)' == ''">Generic</IL2CTargetPlatform>
-        <CoreBuildDependsOn>
-            $(CoreBuildDependsOn);
-            IL2CBuild
-        </CoreBuildDependsOn>
-    </PropertyGroup>
-    <Target Name="IL2CBuild" Outputs="$(IL2COutputPath)">
-        <!-- TODO: Can't use @(IL2CAssemblyPaths) -->
-        <Translate AssemblyPaths="$(IL2CTargetAssemblyPath)" OutputPath="$(IL2COutputPath)" DebugInformation="$(IL2CDebugInformation)" ReadSymbols="$(IL2CReadSymbols)" EnableCpp="$(IL2CEnableCpp)" EnableBundler="$(IL2CEnableBundler)" TargetPlatform="$(IL2CTargetPlatform)" />
-    </Target>
+  <PropertyGroup>
+    <IL2CTargetAssemblyFileName Condition="'$(IL2CTargetAssemblyFileName)' == ''">$([System.String]::Concat('$(AssemblyName)','$(TargetExt)'))</IL2CTargetAssemblyFileName>
+    <IL2CTargetAssemblyPath Condition="'$(IL2CTargetAssemblyPath)' == ''">$([System.IO.Path]::Combine('$(ProjectDir)','$(OutputPath)','$(IL2CTargetAssemblyFileName)'))</IL2CTargetAssemblyPath>
+    <IL2CAssemblyPaths Condition="'$(IL2CAssemblyPaths)' == ''">$(IL2CTargetAssemblyPath)</IL2CAssemblyPaths>
+    <IL2CAssemblyPaths Condition="'$(IL2CAssemblyPaths)' != ''">$([System.String]::Concat('$(IL2CAssemblyPaths)',';','$(IL2CTargetAssemblyPath)').split(';'))</IL2CAssemblyPaths>
+    <IL2COutputPath Condition="'$(IL2COutputPath)' == ''">$([System.IO.Path]::Combine('$(ProjectDir)','$(OutputPath)','IL2C'))</IL2COutputPath>
+    <IL2CDebugInformation Condition="'$(IL2CDebugInformation)' == ''">Full</IL2CDebugInformation>
+    <IL2CReadSymbols Condition="'$(IL2CReadSymbols)' == ''">true</IL2CReadSymbols>
+    <IL2CEnableCpp Condition="'$(IL2CEnableCpp)' == ''">false</IL2CEnableCpp>
+    <IL2CEnableBundler Condition="'$(IL2CEnableBundler)' == ''">false</IL2CEnableBundler>
+    <IL2CTargetPlatform Condition="'$(IL2CTargetPlatform)' == ''">Generic</IL2CTargetPlatform>
+    <CoreBuildDependsOn>
+      $(CoreBuildDependsOn);
+      IL2CBuild
+    </CoreBuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="IL2CBuild" Outputs="$(IL2COutputPath)">
+    <Translate AssemblyPaths="$(IL2CAssemblyPaths)" OutputPath="$(IL2COutputPath)" DebugInformation="$(IL2CDebugInformation)" ReadSymbols="$(IL2CReadSymbols)" EnableCpp="$(IL2CEnableCpp)" EnableBundler="$(IL2CEnableBundler)" TargetPlatform="$(IL2CTargetPlatform)" />
+  </Target>
 </Project>

--- a/docs/supported-opcodes.md
+++ b/docs/supported-opcodes.md
@@ -189,12 +189,12 @@ OpCode | Binary | Implement | Test | ILConverter
 | [starg.s](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.starg_s) | 0x10 |  |  |  |
 | [stelem.any](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem) | 0xa4 | Implemented |  | IL2C.ILConverters.Stelem_anyConvertersConverter |
 | [stelem.i](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i) | 0x9b |  |  |  |
-| [stelem.i1](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i1) | 0x9c |  |  |  |
-| [stelem.i2](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i2) | 0x9d |  |  |  |
+| [stelem.i1](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i1) | 0x9c | Implemented |  | IL2C.ILConverters.Stelem_i1ConvertersConverter |
+| [stelem.i2](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i2) | 0x9d | Implemented |  | IL2C.ILConverters.Stelem_i2ConvertersConverter |
 | [stelem.i4](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i4) | 0x9e | Implemented |  | IL2C.ILConverters.Stelem_i4ConvertersConverter |
-| [stelem.i8](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i8) | 0x9f |  |  |  |
-| [stelem.r4](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r4) | 0xa0 |  |  |  |
-| [stelem.r8](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r8) | 0xa1 |  |  |  |
+| [stelem.i8](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_i8) | 0x9f | Implemented |  | IL2C.ILConverters.Stelem_i8ConvertersConverter |
+| [stelem.r4](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r4) | 0xa0 | Implemented |  | IL2C.ILConverters.Stelem_r4ConvertersConverter |
+| [stelem.r8](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_r8) | 0xa1 | Implemented |  | IL2C.ILConverters.Stelem_r8ConvertersConverter |
 | [stelem.ref](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stelem_ref) | 0xa2 | Implemented |  | IL2C.ILConverters.Stelem_refConvertersConverter |
 | [stfld](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stfld) | 0x7d | Implemented |  | IL2C.ILConverters.StfldConverter |
 | [stind.i](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.stind_i) | 0xdf |  |  |  |


### PR DESCRIPTION
Fix for module discovery, and using the referenced assembly's module for a used type. This enables the original code, to emit 
```
#include <mscorelib.h>
#include <other.library.h>
```
references in the include files to other transpiled dlls' C source code.
