### PR TITLE
Fix alpine build

### DIFF
--- a/tests/IL2C.Core.Test.Common/IL2C.Core.Test.Common.csproj
+++ b/tests/IL2C.Core.Test.Common/IL2C.Core.Test.Common.csproj
@@ -24,6 +24,7 @@
         <DebugType>full</DebugType>
         <DebugSymbols>true</DebugSymbols>
         <Platforms>AnyCPU</Platforms>
+        <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/IL2C.Core.Test.Common/ILSupport.Standard.targets
+++ b/tests/IL2C.Core.Test.Common/ILSupport.Standard.targets
@@ -9,16 +9,9 @@
     -->
     
     <PropertyGroup>
-        <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('windows'))">win</_OSPlatform>
-        <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('linux'))">linux</_OSPlatform>
-        <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('osx'))">osx</_OSPlatform>
-        <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('freebsd'))">freebsd</_OSPlatform>
-        <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('netbsd'))">netbsd</_OSPlatform>
-        <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('illumos'))">illumos</_OSPlatform>
-        <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('solaris'))">solaris</_OSPlatform>
-        <_OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_OSArchitecture>
-
-        <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(_OSPlatform)-$(_OSArchitecture.ToLower())</MicrosoftNetCoreIlasmPackageRuntimeId>
+        <_runtime>$(NETCoreSdkPortableRuntimeIdentifier)</_runtime>
+        <_runtime Condition="'$(_runtime)' == ''">$(NETCoreSdkRuntimeIdentifier)</_runtime>
+        <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(_runtime)</MicrosoftNetCoreIlasmPackageRuntimeId>
         <!-- It's RC version, but latest stable 5.0.0 cause unknown bug (0xc0000004) occurred -->
         <MicrosoftNETCoreILAsmVersion Condition="'$(MicrosoftNETCoreILAsmVersion)' == ''">6.0.0-rc.2.21480.5</MicrosoftNETCoreILAsmVersion>
         <MicrosoftNetCoreIlasmPackageName>runtime.$(MicrosoftNetCoreIlasmPackageRuntimeId).microsoft.netcore.ilasm</MicrosoftNetCoreIlasmPackageName>
@@ -78,7 +71,7 @@
     <Target Name="CoreDecompile" Inputs="@(IntermediateAssembly)" Outputs="$(ILFile)" Condition=" Exists ( @(IntermediateAssembly) ) ">
         <Message Importance="normal" Text="ILSupport: ILDasmPath = $(ILDasmPath)" />
         <PropertyGroup>
-            <ILDasm>&quot;$(ILDasmPath)&quot; /linenum /utf8 /output=&quot;$(ILFile)&quot; @(IntermediateAssembly->'&quot;%(FullPath)&quot;', ' ')</ILDasm>
+            <ILDasm>&quot;$(ILDasmPath)&quot; -linenum -utf8 -output=&quot;$(ILFile)&quot; @(IntermediateAssembly->'&quot;%(FullPath)&quot;', ' ')</ILDasm>
         </PropertyGroup>
         <Exec Command="$(ILDasm)" />
         <ItemGroup>
@@ -102,47 +95,47 @@
     <Target Name="CoreCompileIL" Inputs="@(IL)" Outputs="@(IntermediateAssembly)">
         <Message Importance="normal" Text="ILSupport: ILAsmPath = $(ILAsmPath)" />
         <PropertyGroup>
-            <ILAsm>&quot;$(ILAsmPath)&quot; /nologo /quite /output=@(IntermediateAssembly->'&quot;%(FullPath)&quot;', ' ')</ILAsm>
+            <ILAsm>&quot;$(ILAsmPath)&quot; -nologo -quite -output=@(IntermediateAssembly->'&quot;%(FullPath)&quot;', ' ')</ILAsm>
             <MergedILPath>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)','$(IntermediateOutputPath)','Merged.il'))</MergedILPath>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(FileAlignment)' != '' ">
-            <ILAsm>$(ILAsm) /alignment=$(FileAlignment)</ILAsm>
+            <ILAsm>$(ILAsm) -alignment=$(FileAlignment)</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(BaseAddress)' != '' ">
-            <ILAsm>$(ILAsm) /base=$(BaseAddress)</ILAsm>
+            <ILAsm>$(ILAsm) -base=$(BaseAddress)</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(OutputType)' == 'Library' ">
-            <ILAsm>$(ILAsm) /dll</ILAsm>
+            <ILAsm>$(ILAsm) -dll</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(DebugType)' == 'pdbonly' ">
             <!-- warning : Classic PDB format is not supported on CoreCLR. -->
-            <ILAsm>$(ILAsm) /debug=opt /pdbfmt=portable</ILAsm>
+            <ILAsm>$(ILAsm) -debug=opt -pdbfmt=portable</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(DebugType)' == 'impl' ">
             <!-- warning : Classic PDB format is not supported on CoreCLR. -->
-            <ILAsm>$(ILAsm) /debug=impl /pdbfmt=portable</ILAsm>
+            <ILAsm>$(ILAsm) -debug=impl -pdbfmt=portable</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(DebugType)' == 'portable' ">
             <!-- warning : Classic PDB format is not supported on CoreCLR. -->
-            <ILAsm>$(ILAsm) /debug /pdbfmt=portable</ILAsm>
+            <ILAsm>$(ILAsm) -debug -pdbfmt=portable</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(DebugType)' == 'full' ">
             <!-- warning : Classic PDB format is not supported on CoreCLR. -->
-            <ILAsm>$(ILAsm) /debug /pdbfmt=portable</ILAsm>
+            <ILAsm>$(ILAsm) -debug -pdbfmt=portable</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(Optimize)' == 'true' ">
-            <ILAsm>$(ILAsm) /optimize</ILAsm>
+            <ILAsm>$(ILAsm) -optimize</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(Platform)' == 'Itanium' ">
-            <ILAsm>$(ILAsm) /pe64 /itanium</ILAsm>
+            <ILAsm>$(ILAsm) -pe64 -itanium</ILAsm>
         </PropertyGroup>
         <PropertyGroup Condition=" '$(AssemblyOriginatorKeyFile)' != '' ">
-            <ILAsm>$(ILAsm) /key:"$(AssemblyOriginatorKeyFile)"</ILAsm>
+            <ILAsm>$(ILAsm) -key:"$(AssemblyOriginatorKeyFile)"</ILAsm>
         </PropertyGroup>
         <!-- Couldn't combine resources with ILAsm .NET 5.0 version.
              IL2C regression test doesn't require Win32 resources, so simply omitted.
         <PropertyGroup Condition=" Exists ( '$(ILResourceFile)' ) ">
-            <ILAsm>$(ILAsm) /resource:"$(ILResourceFile)"</ILAsm>
+            <ILAsm>$(ILAsm) -resource:"$(ILResourceFile)"</ILAsm>
         </PropertyGroup>
         -->
         <PropertyGroup Condition=" Exists ( '$(ILFile)' ) ">


### PR DESCRIPTION
Changes in `tests/IL2C.Core.Test.Common/ILSupport.Standard.targets`:
* On Unix-like OS, il{d}asm treat `/` character as a filepath and gives errors where options are passed. Replacing `/` with `-` fixes the problem.
* On musl-libc based distros like Alpine, the runtime being used linux-x64 rather than linux-musl-x64 because of hardcoded list of runtimes. The fix for that is to use `NETCoreSdkPortableRuntimeIdentifier`.
    * Since portable identifier is new in .NET 5 onwards (https://github.com/dotnet/installer/commit/003b1d1d5c287660542b466d2ee0f1868aba5fc4), also added a fallback to `NETCoreSdkRuntimeIdentifier`.
    * This is to support older SDK (do we need netcore 3x, 2x and netfx support?), which is why that part of patch looks a bit different than https://github.com/dotnet/runtime/pull/60400.

Change in `tests/IL2C.Core.Test.Common/IL2C.Core.Test.Common.csproj` was based on feedback I got upstream. This allows us to use `.entrypoint` in IL if we ever wanted.